### PR TITLE
add metadata and resumable download support with tests

### DIFF
--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -139,7 +139,6 @@ class Downloader: NSObject, ObservableObject {
             throw DownloadError.unexpectedError
         }
         
-        let totalSize = Int(response.value(forHTTPHeaderField: "Content-Length") ?? "0") ?? 0
         var downloadedSize = resumeSize
         
         var buffer = Data(capacity: chunkSize)
@@ -153,9 +152,7 @@ class Downloader: NSObject, ObservableObject {
                         try tempFile.write(contentsOf: buffer)
                         buffer.removeAll(keepingCapacity: true)
                         downloadedSize += chunkSize
-                        let progress = Double(downloadedSize) / Double(totalSize + resumeSize)
                         newNumRetries = 5
-                        downloadState.value = .downloading(progress)
                     }
                 }
             }
@@ -164,9 +161,7 @@ class Downloader: NSObject, ObservableObject {
                 try tempFile.write(contentsOf: buffer)
                 downloadedSize += buffer.count
                 buffer.removeAll(keepingCapacity: true)
-                let progress = Double(downloadedSize) / Double(totalSize + resumeSize)
                 newNumRetries = 5
-                downloadState.value = .downloading(progress)
             }
         } catch let error as URLError {
             if newNumRetries <= 0 {

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -399,7 +399,7 @@ public extension HubApi {
             try prepareDestination()
             try prepareMetadataDestination()
 
-            let downloader = Downloader(from: source, to: destination, metadataDirURL: metadataDestination, using: hfToken, inBackground: backgroundSession, expectedSize: remoteSize)
+            let downloader = Downloader(from: source, to: destination, metadataDirURL: metadataDestination, using: hfToken, inBackground: backgroundSession)
             let downloadSubscriber = downloader.downloadState.sink { state in
                 if case .downloading(let progress) = state {
                     progressHandler(progress)

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -369,7 +369,6 @@ public extension HubApi {
             // From now on, etag, commit_hash, url and size are not empty
             guard let remoteCommitHash = remoteMetadata.commitHash,
                   let remoteEtag = remoteMetadata.etag,
-                  let remoteSize = remoteMetadata.size,
                   remoteMetadata.location != "" else {
                 throw EnvironmentError.invalidMetadataError("File metadata must have been retrieved from server")
             }

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -489,7 +489,6 @@ public extension HubApi {
         public let timestamp: Date
     }
 
-
     private func normalizeEtag(_ etag: String?) -> String? {
         guard let etag = etag else { return nil }
         return etag.trimmingPrefix("W/").trimmingCharacters(in: CharacterSet(charactersIn: "\""))

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -145,6 +145,7 @@ class HubApiTests: XCTestCase {
         }
     }
     
+    /// Verify with `curl -I https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel`
     func testGetLargeFileMetadata() async throws {
         do {
             let revision = "eaf97358a37d03fd48e5a87d15aff2e8423c1afb"

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -88,15 +88,6 @@ class HubApiTests: XCTestCase {
         }
     }
     
-    func testHttpHead() async throws {
-        do {
-            let url = URL(string: "https://huggingface.co/argmaxinc/whisperkit-coreml/resolve/main/distil-whisper_distil-large-v3/MelSpectrogram.mlmodelc/coremldata.bin")
-            let metadata = try await Hub.getFileMetadata(fileURL: url!)
-            
-            print(metadata)
-        }
-    }
-    
     func testGetFileMetadata() async throws {
         do {
             let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -303,9 +303,9 @@ class SnapshotDownloadTests: XCTestCase {
                 ".cache/huggingface/config.metadata",
                 ".cache/huggingface/tokenizer.metadata",
                 ".cache/huggingface/tokenizer_config.metadata",
-                ".cache/huggingface/Manifest.metadata",
-                ".cache/huggingface/FeatureDescriptions.metadata",
-                ".cache/huggingface/Metadata.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Manifest.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/FeatureDescriptions.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.metadata",
             ])
         )
     }
@@ -348,9 +348,9 @@ class SnapshotDownloadTests: XCTestCase {
                 ".cache/huggingface/config.metadata",
                 ".cache/huggingface/tokenizer.metadata",
                 ".cache/huggingface/tokenizer_config.metadata",
-                ".cache/huggingface/Manifest.metadata",
-                ".cache/huggingface/FeatureDescriptions.metadata",
-                ".cache/huggingface/Metadata.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Manifest.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/FeatureDescriptions.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.metadata",
             ])
         )
         
@@ -405,9 +405,9 @@ class SnapshotDownloadTests: XCTestCase {
                 ".cache/huggingface/config.metadata",
                 ".cache/huggingface/tokenizer.metadata",
                 ".cache/huggingface/tokenizer_config.metadata",
-                ".cache/huggingface/Manifest.metadata",
-                ".cache/huggingface/FeatureDescriptions.metadata",
-                ".cache/huggingface/Metadata.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Manifest.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/FeatureDescriptions.metadata",
+                ".cache/huggingface/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.metadata",
             ])
         )
         

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -144,6 +144,25 @@ class HubApiTests: XCTestCase {
             XCTAssertGreaterThan(metadata.size!, 0)
         }
     }
+    
+    func testGetLargeFileMetadata() async throws {
+        do {
+            let revision = "eaf97358a37d03fd48e5a87d15aff2e8423c1afb"
+            let etag = "fc329090bfbb2570382c9af997cffd5f4b78b39b8aeca62076db69534e020107"
+            let location = "https://cdn-lfs.hf.co/repos/4a/4e/4a4e587f66a2979dcd75e1d7324df8ee9ef74be3582a05bea31c2c26d0d467d0/fc329090bfbb2570382c9af997cffd5f4b78b39b8aeca62076db69534e020107?response-content-disposition=inline%3B+filename*%3DUTF-8%27%27model.mlmodel%3B+filename%3D%22model.mlmodel"
+            let size = 504766
+            
+            let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel")
+            let metadata = try await Hub.getFileMetadata(fileURL: url!)
+                        
+            XCTAssertEqual(metadata.commitHash, revision)
+            XCTAssertNotNil(metadata.etag, etag)
+            XCTAssertTrue(metadata.location.contains(location))
+            XCTAssertEqual(metadata.size, size)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }
 
 class SnapshotDownloadTests: XCTestCase {

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -88,6 +88,15 @@ class HubApiTests: XCTestCase {
         }
     }
     
+    func testHttpHead() async throws {
+        do {
+            let url = URL(string: "https://huggingface.co/argmaxinc/whisperkit-coreml/resolve/main/distil-whisper_distil-large-v3/MelSpectrogram.mlmodelc/coremldata.bin")
+            let metadata = try await Hub.getFileMetadata(fileURL: url!)
+            
+            print(metadata)
+        }
+    }
+    
     func testGetFileMetadata() async throws {
         do {
             let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")

--- a/Tests/TensorUtilsTests/WeightsTests.swift
+++ b/Tests/TensorUtilsTests/WeightsTests.swift
@@ -13,7 +13,6 @@ class WeightsTests: XCTestCase {
     func testLoadWeightsFromFileURL() async throws {
         let repo = "google/bert_uncased_L-2_H-128_A-2"
         let modelDir = try await hubApi.snapshot(from: repo, matching: ["config.json", "model.safetensors"])
-        print(modelDir)
 
         let files = try FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: [.isReadableKey])
         XCTAssertTrue(files.contains(where: { $0.lastPathComponent == "config.json" }))

--- a/Tests/TensorUtilsTests/WeightsTests.swift
+++ b/Tests/TensorUtilsTests/WeightsTests.swift
@@ -13,6 +13,7 @@ class WeightsTests: XCTestCase {
     func testLoadWeightsFromFileURL() async throws {
         let repo = "google/bert_uncased_L-2_H-128_A-2"
         let modelDir = try await hubApi.snapshot(from: repo, matching: ["config.json", "model.safetensors"])
+        print(modelDir)
 
         let files = try FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: [.isReadableKey])
         XCTAssertTrue(files.contains(where: { $0.lastPathComponent == "config.json" }))


### PR DESCRIPTION
This PR aims to bring over some of huggingface_hub Python library's capabilities to swift-transformers:

- Disables automatic redirection during head requests to fix getFileMetadata, which currently doesn't return expected commit hash and etag for lfs files.
- Adds resumable downloads by downloading HuggingFace files in async bytes, stores them in 10MB buffers and writes buffers to memory.
- Adds retry logic to downloads to mitigate connection errors during downloading.
- Adds file metadata support to prevent unnecessary redownloads and ensure file integrity.
- Adds additional tests to verify metadata and download logic.